### PR TITLE
fixed button selection bug

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -225,7 +225,7 @@ var PageControl = (function(){
         console.log("Me me me");
         var thiz = e.data.context,
             dataLayer = GEODATA;
-        thiz.population = $(this).data("group-id") || $(e.target).val();
+        thiz.population = typeof $(this).data("group-id") === 'number' ? $(this).data("group-id") : $(e.target).val();
         var options = thiz.getOptions();
         //console.log(thiz);
         // change toggle button CSS to indicate "active"


### PR DESCRIPTION
Fixed bug where reselecting the "Black/African American Studies" button did not populate map with data.

To recreate:
- Select the "Asian Students" button
- Reselect the "Black/African American Studies" button
- Data does not load