### PR TITLE
fix bug where some districts didn't update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project includes a command line utility for generating the data used to pop
 
 To set up a Python environment that can run the utility, use pipenv. If needed, follow the [pipenv installation instructions](https://pipenv.readthedocs.io/en/latest/) before you continue. Once pipenv is installed, use this pipenv command to install the Python libraries you need:
 
-```$ pipenv install --dev```
+```$ pipenv install```
 
 If you need to install or manage different versions of Python in order to run the required version for this project (pipenv will give you a warning), consider [pyenv](https://github.com/pyenv/pyenv) which pipenv integrates with directly.
 
@@ -70,7 +70,9 @@ You can use the `-f` and `-l` flags to set the first and last years of the range
 
 ```$ collectFromFile -f 2012 -l 2015```
 
-If you use the `--json-folders` flag, you'll get nested directories labeled by year, demographic, and punishment, with JSON files each containing the data corresponding to one possible user query. The current version of the map is set up to use data exported using the `--json-folders` flag.
+### Output Format
+
+The three options to output the processed data are `--json-folders`, `--csv`, and `--json`. The current version of the map is set up to use data exported using the `--json-folders` option. That option is also the default, so if you don't include any of these three flags, you get the `--json-folders` format, which includes nested directories labeled by year, demographic, and punishment. Each JSON file contains the data corresponding to one possible user query.
 
 ```$ collectFromFile --json-folders```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to one of ten categories of students, with the following abbreviations:
 * HIS: HISPANIC
 * BLA: BLACK OR AFRICAN AMERICAN
 * WHI: WHITE
-* IND: NATIVE AMERICAN
+* IND: INDIGENOUS AMERICAN
 * ASI: ASIAN
 * PCI: NATIVE HAWAIIAN/OTHER PACIFIC
 * TWO: TWO OR MORE RACES

--- a/js/index.js
+++ b/js/index.js
@@ -120,6 +120,75 @@ var PageControl = (function(){
         this.loadGeojsonLayer(options);
     };
 
+    Map.prototype.getPopupContent = function (districtName, groupNameInPopup, punishmentType) {
+
+        var popupContent;
+
+        if (this.punishmentOfThisGroup && this.scale == -1) {
+            if (this.population == "All Students") {
+                popupContent = [
+                "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
+                            "They report that there were " + this.populationOfThisGroup.toLocaleString(),
+                            " students in the district and that they received " + this.punishmentOfThisGroup.toLocaleString(),
+                            " <b>" + punishmentType + "</b>, out of a statewide total of " + this.punishmentTotal.toLocaleString(),
+                            ".</span>"
+                ].join('');
+            }
+            else {
+                popupContent = [
+                "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
+                           "They report that there were " + this.populationOfThisGroup.toLocaleString(),
+                           " <b>" + groupNameInPopup + "</b> and that they received " + this.punishmentOfThisGroup.toLocaleString(),
+                           " <b>" + punishmentType + "</b>, out of a district total of ",
+                           (this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
+                           ".</span>"
+                ].join('');
+        }
+        }
+        else if (this.punishmentTotal === 0) {
+
+            popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + punishmentType + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
+        }
+        else if (this.populationOfThisGroup === 0) {
+
+            popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + groupNameInPopup + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
+        }
+        else if (this.punishmentTotal !== null){
+            const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
+            const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
+            if (this.population == "All Students") {
+            popupContent = [
+                "<span class='popup-text'>",
+                "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
+                " students received " + Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the state's ",
+                (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
+                " <b>" + punishmentType + "</b> and represented ",
+                Math.round(percentStudentsByGroup*100)/100.0 + "% of the state's student population.",
+                "</span>"
+            ].join('');}
+            else {
+                popupContent = [
+                    "<span class='popup-text'>",
+                    "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
+                    " <b>" + groupNameInPopup + "</b> received ",
+                    (0 < this.punishmentTotal && this.punishmentTotal < 10 && punishmentPercent != 0) ? "about " : "",
+                    Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the ",
+                    (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
+                    " <b>" + punishmentType + "</b> and represented ",
+                    Math.round(percentStudentsByGroup*100)/100.0 + "% of the student population.",
+                    "</span>"
+                ].join('');}
+        }
+        else {
+            popupContent = [
+                "<span class='popup-text'>Data not available in <b>" + districtName,
+                "</b> for <b>" + groupNameInPopup + "</b> in the <b>" + this.schoolYear,
+                "</b> school year.",
+                "</span>"
+            ].join('');
+        }
+        return popupContent;
+    };
 
     Map.prototype.getOptions = function () {
         return {
@@ -158,71 +227,8 @@ var PageControl = (function(){
 
                 const districtName = feature.properties.district_name;
 
-                var popupContent;
+                var popupContent = this.getPopupContent(districtName, groupNameInPopup, punishmentType);
 
-                if (this.punishmentOfThisGroup && this.scale == -1) {
-                    if (this.population == "All Students") {
-                        popupContent = [
-                        "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
-                                    "They report that there were " + this.populationOfThisGroup.toLocaleString(),
-                                    " students in the district and that they received " + this.punishmentOfThisGroup.toLocaleString(),
-                                    " <b>" + punishmentType + "</b>, out of a statewide total of " + this.punishmentTotal.toLocaleString(),
-                                    ".</span>"
-                        ].join('');
-                    }
-                    else {
-                        popupContent = [
-                        "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
-                                   "They report that there were " + this.populationOfThisGroup.toLocaleString(),
-                                   " <b>" + groupNameInPopup + "</b> and that they received " + this.punishmentOfThisGroup.toLocaleString(),
-                                   " <b>" + punishmentType + "</b>, out of a district total of ",
-                                   (this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                                   ".</span>"
-                        ].join('');
-                }
-                }
-                else if (this.punishmentTotal === 0) {
-
-                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + punishmentType + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
-                }
-                else if (this.populationOfThisGroup === 0) {
-
-                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + groupNameInPopup + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
-                }
-                else if (this.punishmentTotal !== null){
-                    const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
-                    const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
-                    if (this.population == "All Students") {
-                    popupContent = [
-                        "<span class='popup-text'>",
-                        "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
-                        " students received " + Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the state's ",
-                        (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                        " <b>" + punishmentType + "</b> and represented ",
-                        Math.round(percentStudentsByGroup*100)/100.0 + "% of the state's student population.",
-                        "</span>"
-                    ].join('');}
-                    else {
-                        popupContent = [
-                            "<span class='popup-text'>",
-                            "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
-                            " <b>" + groupNameInPopup + "</b> received ",
-                            (0 < this.punishmentTotal && this.punishmentTotal < 10 && punishmentPercent != 0) ? "about " : "",
-                            Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the ",
-                            (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                            " <b>" + punishmentType + "</b> and represented ",
-                            Math.round(percentStudentsByGroup*100)/100.0 + "% of the student population.",
-                            "</span>"
-                        ].join('');}
-                }
-                else {
-                    popupContent = [
-                        "<span class='popup-text'>Data not available in <b>" + districtName,
-                        "</b> for <b>" + groupNameInPopup + "</b> in the <b>" + this.schoolYear,
-                        "</b> school year.",
-                        "</span>"
-                    ].join('');
-                }
                 if (feature.properties) layer.bindPopup(popupContent);
             }.bind(this)
         };

--- a/js/index.js
+++ b/js/index.js
@@ -89,7 +89,6 @@ var PageControl = (function(){
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
         });
 
-
         // Default Stripes.
         this.stripes = new L.StripePattern({
             weight: 1,
@@ -140,7 +139,7 @@ var PageControl = (function(){
                 ((this.populationOfThisGroup === 0) ? groupNameInPopup : punishmentType) +
                 "</b> for the <b>" + this.schoolYear + "</b> school year.";
         }
-        else if (this.punishmentTotal !== null){
+        else if (this.punishmentTotal !== null && this.populationOfThisGroup !== null){
             const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
             const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
             popupContent = "In <b>" + districtName + "</b>, the " +

--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,7 @@ viewable in the map by changing the line to "lastYear = 2017;"
 firstYear = 2006;
 lastYear = 2016;
 
-// Copyright (c) 2013 Ryan Clark
+// This section Copyright (c) 2013 Ryan Clark -- under MIT License
 // https://gist.github.com/rclark/5779673
 L.TopoJSON = L.GeoJSON.extend({
     addData: function(jsonData) {
@@ -63,8 +63,6 @@ var PageControl = (function(){
 
     function Map( selector ) {
 
-        // Rename 'this' for use in callbacks
-        var thisMap = this;
         this.punishment = "Out of School Suspensions";
         this.population = "Black/African American Students";
         this.punishmentKey = punishmentToProcessedDataKey[this.punishment];
@@ -123,71 +121,42 @@ var PageControl = (function(){
     Map.prototype.getPopupContent = function (districtName, groupNameInPopup, punishmentType) {
 
         var popupContent;
+        if (this.population == "All Students") {
+            groupNameInPopup = "students";
+            this.populationScope = "statewide"; }
+        else {this.populationScope = "district"; }
 
         if (this.punishmentOfThisGroup && this.scale == -1) {
-            if (this.population == "All Students") {
-                popupContent = [
-                "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
-                            "They report that there were " + this.populationOfThisGroup.toLocaleString(),
-                            " students in the district and that they received " + this.punishmentOfThisGroup.toLocaleString(),
-                            " <b>" + punishmentType + "</b>, out of a statewide total of " + this.punishmentTotal.toLocaleString(),
-                            ".</span>"
-                ].join('');
-            }
-            else {
-                popupContent = [
-                "<span class='popup-text'>The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. ",
-                           "They report that there were " + this.populationOfThisGroup.toLocaleString(),
-                           " <b>" + groupNameInPopup + "</b> and that they received " + this.punishmentOfThisGroup.toLocaleString(),
-                           " <b>" + punishmentType + "</b>, out of a district total of ",
-                           (this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                           ".</span>"
-                ].join('');
+            popupContent = "The statistics for <b>" + districtName + "</b> appear to have an <b>error</b>. " +
+                "They report that there were " + this.populationOfThisGroup.toLocaleString() +
+                " <b>" + groupNameInPopup + "</b> and that they received " +
+                this.punishmentOfThisGroup.toLocaleString() + " <b>" + punishmentType +
+                "</b>, out of a " + this.populationScope + " total of " +
+                ((this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString()) + ".";
         }
-        }
-        else if (this.punishmentTotal === 0) {
+        else if (this.punishmentTotal === 0 || this.populationOfThisGroup === 0) {
 
-            popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + punishmentType + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
-        }
-        else if (this.populationOfThisGroup === 0) {
-
-            popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + groupNameInPopup + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
+            popupContent = districtName + " reported that it had no <b>" +
+                ((this.populationOfThisGroup === 0) ? groupNameInPopup : punishmentType) +
+                "</b> for the <b>" + this.schoolYear + "</b> school year.";
         }
         else if (this.punishmentTotal !== null){
             const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
             const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
-            if (this.population == "All Students") {
-            popupContent = [
-                "<span class='popup-text'>",
-                "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
-                " students received " + Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the state's ",
-                (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                " <b>" + punishmentType + "</b> and represented ",
-                Math.round(percentStudentsByGroup*100)/100.0 + "% of the state's student population.",
-                "</span>"
-            ].join('');}
-            else {
-                popupContent = [
-                    "<span class='popup-text'>",
-                    "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
-                    " <b>" + groupNameInPopup + "</b> received ",
-                    (0 < this.punishmentTotal && this.punishmentTotal < 10 && punishmentPercent != 0) ? "about " : "",
-                    Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the ",
-                    (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
-                    " <b>" + punishmentType + "</b> and represented ",
-                    Math.round(percentStudentsByGroup*100)/100.0 + "% of the student population.",
-                    "</span>"
-                ].join('');}
-        }
+            popupContent = "In <b>" + districtName + "</b>, the " +
+                this.populationOfThisGroup.toLocaleString() + " <b>" + groupNameInPopup + "</b> received " +
+                ((0 < this.punishmentTotal && this.punishmentTotal < 10 && punishmentPercent != 0) ? "about " : "") +
+                Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the " +
+                ((0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString()) +
+                " <b>" + punishmentType + "</b> and represented " + Math.round(percentStudentsByGroup*100)/100.0 +
+                "% of the " + this.populationScope + " population.";
+            }
         else {
-            popupContent = [
-                "<span class='popup-text'>Data not available in <b>" + districtName,
-                "</b> for <b>" + groupNameInPopup + "</b> in the <b>" + this.schoolYear,
-                "</b> school year.",
-                "</span>"
-            ].join('');
+            popupContent = "Data not available in <b>" + districtName +
+                "</b> for <b>" + groupNameInPopup + "</b> in the <b>" + this.schoolYear +
+                "</b> school year.";
         }
-        return popupContent;
+        return ["<span class='popup-text'>", "</span>"].join(popupContent);
     };
 
     Map.prototype.getOptions = function () {
@@ -362,7 +331,6 @@ var PageControl = (function(){
         }
     };
 
-
     Map.prototype.getFillColor =   function (value) {
         var red    = ['#fcbba1','#fc9272','#fb6a4a','#de2d26','#aa0208'],
         purple = ['#d8daeb','#b2abd2','#8073ac','#542788','#2d004b'],
@@ -381,7 +349,6 @@ var PageControl = (function(){
         value == 10  ? red[4]  :
         gray;
     };
-
 
     // Return a reference to the map
     return(new Map( "#leMap" ));

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,15 @@
 /*jshint esversion: 6 */
 
+/*
+The firstYear and lastYear variables are the first and last years
+available in the map's drop-down menu. So, if you're able to add
+2017 data to the data/ directory, you can then make that data
+viewable in the map by changing the line to "lastYear = 2017;"
+*/
+
+firstYear = 2006;
+lastYear = 2016;
+
 // Copyright (c) 2013 Ryan Clark
 // https://gist.github.com/rclark/5779673
 L.TopoJSON = L.GeoJSON.extend({
@@ -37,8 +47,9 @@ const punishmentToProcessedDataKey = {
 
 // populate year selector with choices
 var yearSelector = document.querySelector('.year_selector');
-// this line assumes 2016 is the last available year of data
-for (year = 2006; year <= 2016; year++) {
+
+// currently this adds years 2006 through 2016
+for (year = firstYear; year <= lastYear; year++) {
     var yearEntry = document.createElement('option');
     yearEntry.textContent = (year - 1) + "-" + year;
     yearEntry.value = year;
@@ -195,7 +206,9 @@ var PageControl = (function(){
                         popupContent = [
                             "<span class='popup-text'>",
                             "In <b>" + districtName + "</b>, the " + this.populationOfThisGroup.toLocaleString(),
-                            " <b>" + groupNameInPopup + "</b> received " + Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the ",
+                            " <b>" + groupNameInPopup + "</b> received ",
+                            (0 < this.punishmentTotal && this.punishmentTotal < 10 && punishmentPercent != 0) ? "about " : "",
+                            Math.min(100, Math.round(punishmentPercent*100)/100.0) + "% of the ",
                             (0 < this.punishmentTotal && this.punishmentTotal < 10) ? "fewer than 10" : this.punishmentTotal.toLocaleString(),
                             " <b>" + punishmentType + "</b> and represented ",
                             Math.round(percentStudentsByGroup*100)/100.0 + "% of the student population.",

--- a/js/index.js
+++ b/js/index.js
@@ -150,10 +150,10 @@ var PageControl = (function(){
                 }
                 else {
                     this.scale = -1;
-                    this.populationOfThisGroup = undefined;
-                    this.populationTotal = undefined;
-                    this.punishmentOfThisGroup = undefined;
-                    this.punishmentTotal = undefined;
+                    this.populationOfThisGroup = null;
+                    this.populationTotal = null;
+                    this.punishmentOfThisGroup = null;
+                    this.punishmentTotal = null;
                 }
 
                 const districtName = feature.properties.district_name;
@@ -183,13 +183,13 @@ var PageControl = (function(){
                 }
                 else if (this.punishmentTotal === 0) {
 
-                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no " + punishmentType + " for the <b>" + this.schoolYear + "</b> school year.</span>";
+                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + punishmentType + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
                 }
                 else if (this.populationOfThisGroup === 0) {
 
-                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no " + groupNameInPopup + " for the <b>" + this.schoolYear + "</b> school year.</span>";
+                    popupContent = "<span class='popup-text'>" + districtName + " reported that it had no <b>" + groupNameInPopup + "</b> for the <b>" + this.schoolYear + "</b> school year.</span>";
                 }
-                else if (this.populationTotal){
+                else if (this.punishmentTotal !== null){
                     const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
                     const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
                     if (this.population == "All Students") {


### PR DESCRIPTION
Replacing "undefined" with "null" in the onEachFeature function seemed to fix a bug where some districts didn't update their popup messages. For example, if you select "In School Suspension"--"Students of Two or More Races"--"2015-2016", Travis County would continue to show the popup message for whatever you had selected before that.

I don't really understand the bug, and also I'm not clear on how to write a regression test for it.